### PR TITLE
feat: add role-based margin visibility in checkout

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -16,6 +16,7 @@ type AppSettings {
   salesRepresentative: Int!
   salesManager: Int!
   salesAdmin: Int!
+  rolesAllowedToSeeMargin: [String]
 }
 
 type Query {

--- a/manifest.json
+++ b/manifest.json
@@ -154,6 +154,29 @@
         "description": "Set the discount value to be applied by the sales admin",
         "type": "number",
         "default": 0
+      },
+      "rolesAllowedToSeeMargin": {
+        "title": "Roles allowed to see margin",
+        "description": "Set the roles that are allowed to see the margin in the checkout",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "store-admin",
+            "sales-admin",
+            "sales-manager",
+            "sales-representative",
+            "customer-admin",
+            "customer-approver",
+            "customer-buyer"
+          ]
+        },
+        "default": [
+          "store-admin",
+          "sales-admin",
+          "sales-manager",
+          "sales-representative"
+        ]
       }
     }
   },

--- a/manifest.json
+++ b/manifest.json
@@ -158,25 +158,41 @@
       "rolesAllowedToSeeMargin": {
         "title": "Roles allowed to see margin",
         "description": "Set the roles that are allowed to see the margin in the checkout",
-        "type": "array",
-        "items": {
-          "type": "string",
-          "enum": [
-            "store-admin",
-            "sales-admin",
-            "sales-manager",
-            "sales-representative",
-            "customer-admin",
-            "customer-approver",
-            "customer-buyer"
-          ]
-        },
-        "default": [
-          "store-admin",
-          "sales-admin",
-          "sales-manager",
-          "sales-representative"
-        ]
+        "type": "object",
+        "properties": {
+          "store-admin": {
+            "type": "boolean",
+            "title": "Store Admin",
+            "default": true
+          },
+          "sales-admin": {
+            "type": "boolean",
+            "title": "Sales Admin",
+            "default": true
+          },
+          "sales-manager": {
+            "type": "boolean",
+            "title": "Sales Manager",
+            "default": true
+          },
+          "sales-representative": {
+            "type": "boolean",
+            "title": "Sales Representative",
+            "default": true
+          },
+          "customer-admin": {
+            "type": "boolean",
+            "title": "Customer Admin"
+          },
+          "customer-approver": {
+            "type": "boolean",
+            "title": "Customer Approver"
+          },
+          "customer-buyer": {
+            "type": "boolean",
+            "title": "Customer Buyer"
+          }
+        }
       }
     }
   },

--- a/node/resolvers/queries/getAppSettings.ts
+++ b/node/resolvers/queries/getAppSettings.ts
@@ -7,5 +7,18 @@ export const getAppSettings = async (
   __: unknown,
   context: ServiceContext<Clients>
 ) => {
-  return context.clients.apps.getAppSettings(process.env.VTEX_APP_ID ?? '')
+  const settings = await context.clients.apps.getAppSettings(
+    process.env.VTEX_APP_ID ?? ''
+  )
+
+  const rolesAllowedToSeeMargin = settings.rolesAllowedToSeeMargin
+    ? Object.entries(settings.rolesAllowedToSeeMargin)
+        .filter(([, isAllowed]) => isAllowed)
+        .map(([role]) => role)
+    : []
+
+  return {
+    ...settings,
+    rolesAllowedToSeeMargin,
+  }
 }

--- a/react/CheckoutB2B.tsx
+++ b/react/CheckoutB2B.tsx
@@ -1,8 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useMutation, useQuery } from 'react-apollo'
+import { useMutation } from 'react-apollo'
 import { useIntl } from 'react-intl'
-import { Query } from 'ssesandbox04.checkout-b2b'
 import { MutationSetManualPrice } from 'vtex.checkout-resources'
 import 'vtex.country-codes/locales'
 import { useCssHandles } from 'vtex.css-handles'
@@ -26,7 +25,6 @@ import {
 import { ContactInfos } from './components/ContactInfos'
 import ProductAutocomplete from './components/ProductAutocomplete'
 import { SavedCarts } from './components/SavedCarts'
-import GET_APP_SETTINGS from './graphql/getAppSettings.graphql'
 import {
   useClearCart,
   useOrderFormCustom,
@@ -41,8 +39,6 @@ import { queryClient } from './services'
 import './styles.css'
 import { CompleteOrderForm } from './typings'
 import { messages, SEARCH_TYPE, welcome } from './utils'
-
-type AppSettingsQuery = Pick<Query, 'getAppSettings'>
 
 function CheckoutB2B() {
   const handles = useCssHandles(['container', 'table', 'containerToggle'])
@@ -83,8 +79,7 @@ function CheckoutB2B() {
 
   const showToast = useToast()
 
-  const { data } = useQuery<AppSettingsQuery>(GET_APP_SETTINGS, { ssr: false })
-  const { maximumDiscount, isSalesUser } = usePermissions(data?.getAppSettings)
+  const { maximumDiscount, isSalesUser } = usePermissions()
 
   useEffect(() => {
     if (listedPrice > 0) {

--- a/react/graphql/getAppSettings.graphql
+++ b/react/graphql/getAppSettings.graphql
@@ -3,5 +3,6 @@ query getSettings {
     salesRepresentative
     salesManager
     salesAdmin
+    rolesAllowedToSeeMargin
   }
 }

--- a/react/hooks/useFetchPrices.ts
+++ b/react/hooks/useFetchPrices.ts
@@ -32,13 +32,13 @@ export function useFetchPrices(skuId: string, priceTable: string) {
 export function useTotalMargin() {
   const { orderForm } = useOrderFormCustom()
   const { organization } = useOrganization()
-  const { isSalesUser } = usePermissions()
+  const { canSeeMargin } = usePermissions()
   const { items } = orderForm
   const priceTable = organization?.priceTables?.[0] ?? '1'
 
   const { data } = useQuery<PriceResponse[], Error>({
     queryKey: ['fetchPrices', priceTable, items],
-    enabled: isSalesUser && !!items.length,
+    enabled: canSeeMargin && !!items.length,
     queryFn: async () =>
       Promise.all(
         items.map((item) =>

--- a/react/hooks/usePermissions.ts
+++ b/react/hooks/usePermissions.ts
@@ -6,6 +6,7 @@ interface AppSettings {
   salesRepresentative: number
   salesManager: number
   salesAdmin: number
+  rolesAllowedToSeeMargin?: string[]
 }
 
 export function usePermissions(appSettings?: AppSettings | undefined) {
@@ -39,5 +40,10 @@ export function usePermissions(appSettings?: AppSettings | undefined) {
     }
   }, [appSettings, role])
 
-  return { isSalesUser, maximumDiscount }
+  const canSeeMargin = useMemo(
+    () => appSettings?.rolesAllowedToSeeMargin?.includes(role) ?? false,
+    [appSettings, role]
+  )
+
+  return { isSalesUser, maximumDiscount, canSeeMargin }
 }

--- a/react/hooks/usePermissions.ts
+++ b/react/hooks/usePermissions.ts
@@ -1,6 +1,11 @@
 import { useMemo } from 'react'
+import { useQuery } from 'react-apollo'
+import { Query } from 'ssesandbox04.checkout-b2b'
 
 import { useOrganization } from '.'
+import GET_APP_SETTINGS from '../graphql/getAppSettings.graphql'
+
+type AppSettingsQuery = Pick<Query, 'getAppSettings'>
 
 interface AppSettings {
   salesRepresentative: number
@@ -9,7 +14,13 @@ interface AppSettings {
   rolesAllowedToSeeMargin?: string[]
 }
 
-export function usePermissions(appSettings?: AppSettings | undefined) {
+export function usePermissions() {
+  const { data } = useQuery<AppSettingsQuery>(GET_APP_SETTINGS, {
+    ssr: false,
+  })
+
+  const appSettings = data?.getAppSettings as AppSettings
+
   const { organization } = useOrganization()
   const { role } = organization
 

--- a/react/hooks/useTableSchema.tsx
+++ b/react/hooks/useTableSchema.tsx
@@ -3,10 +3,7 @@ import { useIntl } from 'react-intl'
 import { FormattedPrice } from 'vtex.formatted-price'
 import { OrderItems } from 'vtex.order-items'
 import { ButtonWithIcon, IconDelete, Tooltip } from 'vtex.styleguide'
-import { useQuery } from 'react-apollo'
-import type { Query } from 'ssesandbox04.checkout-b2b'
 
-import GET_APP_SETTINGS from '../graphql/getAppSettings.graphql'
 import { useOrderFormCustom, usePermissions, useTotalMargin } from '.'
 import { useCheckoutB2BContext } from '../CheckoutB2BContext'
 import ManualPrice from '../components/ManualPrice'
@@ -15,8 +12,6 @@ import { QuantitySelector } from '../components/QuantitySelector'
 import { TruncatedText } from '../components/TruncatedText'
 import type { CustomItem, TableSchema } from '../typings'
 import { isWithoutStock, messages, normalizeString } from '../utils'
-
-type AppSettingsQuery = Pick<Query, 'getAppSettings'>
 
 const { useOrderItems } = OrderItems
 
@@ -29,13 +24,11 @@ export function useTableSchema(
   discount: number,
   onUpdatePrice: (id: string, newPrice: number) => void
 ): TableSchema<CustomItem> {
-  const { data } = useQuery<AppSettingsQuery>(GET_APP_SETTINGS, { ssr: false })
-
   const { hasMargin } = useTotalMargin()
   const { orderForm } = useOrderFormCustom()
   const { formatMessage } = useIntl()
   const { removeItem } = useOrderItems()
-  const { canSeeMargin } = usePermissions(data?.getAppSettings)
+  const { canSeeMargin } = usePermissions()
   const {
     getSellingPrice,
     getDiscountedPrice,


### PR DESCRIPTION
#### What problem is this solving?

Previously, the margin column was either shown or hidden statically, without flexibility to control which user roles had permission to view it. This posed a problem for organizations with varying permission levels among sales staff and clients.

This update introduces a dynamic permission system to control visibility of the margin column in the checkout table. The roles allowed to see the margin can now be configured through the app settings (`rolesAllowedToSeeMargin` field). The logic was implemented using the `usePermissions` hook, which fetches the current user's role from the organization context and checks it against the configured roles in the app settings.

#### How to test it?

1. Go to the settings page and define which roles can see the margin column:  
   [`/admin/app/apps/ssesandbox04.checkout-b2b@1.0.33/setup`](https://raabelo--bravtexfashionb2b.myvtex.com)

2. Navigate to the checkout B2B page as a user with a configured role:  
   [`/checkout-b2b`](https://raabelo--bravtexfashionb2b.myvtex.com)

3. The margin column should appear only if the current user's role is included in the allowed roles set in the app settings.

#### Screenshots or example usage:

<!-- Add before/after screenshots if available -->

#### Describe alternatives you've considered, if any.

We considered using fixed roles directly in the code, but this would not offer flexibility across different clients and use cases. A settings-driven approach makes the feature reusable and customizable.

#### Related to / Depends on

N/A

#### How does this PR make you feel? [:link:](http://giphy.com/)
