### PR TITLE
feat: update back link on saved carts page to go to checkout

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -59,6 +59,7 @@
   "store/checkout.b2b.column.item": "Items",
 
   "store/checkout.b2b.button.backToHome": "Back to home page",
+  "store/checkout.b2b.button.backToCheckout": "Back to checkout",
   "store/checkout.b2b.button.clearCart": "Clear cart",
   "store/checkout.b2b.button.removeItem": "Remove item",
   "store/checkout.b2b.button.placeOrder": "Place Order",

--- a/messages/es.json
+++ b/messages/es.json
@@ -59,6 +59,7 @@
   "store/checkout.b2b.column.item": "Elementos",
 
   "store/checkout.b2b.button.backToHome": "Volver a la página de inicio",
+  "store/checkout.b2b.button.backToCheckout": "Volver a la página de checkout",
   "store/checkout.b2b.button.clearCart": "Limpiar carrito",
   "store/checkout.b2b.button.removeItem": "Eliminar",
   "store/checkout.b2b.button.placeOrder": "Finalizar Pedido",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -59,6 +59,7 @@
   "store/checkout.b2b.column.item": "Itens",
 
   "store/checkout.b2b.button.backToHome": "Voltar à página inicial",
+  "store/checkout.b2b.button.backToCheckout": "Voltar para o checkout",
   "store/checkout.b2b.button.clearCart": "Limpar carrinho",
   "store/checkout.b2b.button.removeItem": "Remover",
   "store/checkout.b2b.button.placeOrder": "Finalizar Pedido",

--- a/react/B2BSavedCarts.tsx
+++ b/react/B2BSavedCarts.tsx
@@ -23,10 +23,10 @@ export default function B2BSavedCarts() {
             pageHeader={
               <PageHeader
                 title={<ExtensionPoint id="rich-text" />}
-                linkLabel={formatMessage(messages.backToHome)}
+                linkLabel={formatMessage(messages.backToCheckout)}
                 onLinkClick={() =>
                   navigate({
-                    page: 'store.home',
+                    page: 'store.checkout-b2b',
                     fallbackToWindowLocation: true,
                   })
                 }

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -41,6 +41,7 @@ export const messages = defineMessages({
   category: { id: 'store/checkout.b2b.column.category' },
   brand: { id: 'store/checkout.b2b.column.brand' },
   backToHome: { id: 'store/checkout.b2b.button.backToHome' },
+  backToCheckout: { id: 'store/checkout.b2b.button.backToCheckout' },
   refId: { id: 'store/checkout.b2b.column.refId' },
   seller: { id: 'store/checkout.b2b.column.seller' },
   margin: { id: 'store/checkout.b2b.column.margin' },


### PR DESCRIPTION
#### What problem is this solving?

This updates the "back" button on the `/checkout-b2b/saved-carts` page to improve user navigation. The button now displays "Back to checkout" and correctly redirects to the `store.checkout-b2b` page.

#### How to test it?

Visit the saved carts page (`/checkout-b2b/saved-carts`) in the workspace below and check that:
- The back button label is now "Back to checkout".
- Clicking the button redirects the user to the custom checkout page.

[Workspace](https://raabelo--bravtexfashionb2b.myvtex.com/checkout-b2b/saved-carts)

#### Screenshots or example usage:

**Before:**
- Link text: "Back to home page"
- Navigation: it was returning to initial page of the store

**After:**
- Link text: "Back to checkout"
- Navigation: correctly routes to `store.checkout-b2b`

