### PR TITLE
feat: add a box to totalizers in checkout screen

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -28,6 +28,7 @@
   "store/checkout.b2b.savedCarts.save-cart.current": "Save cart in the same transaction",
   "store/checkout.b2b.savedCarts.save-cart.new": "Save cart in a new transaction",
 
+  "store/checkout.b2b.totalizer.boxTitle": "Order Header",
   "store/checkout.b2b.totalizer.shippingAddress": "Shipping",
   "store/checkout.b2b.totalizer.billingAddress": "Billing Address",
   "store/checkout.b2b.totalizer.editAddress": "Edit",

--- a/messages/es.json
+++ b/messages/es.json
@@ -28,6 +28,7 @@
   "store/checkout.b2b.savedCarts.save-cart.current": "Guardar carrito en la misma transacción",
   "store/checkout.b2b.savedCarts.save-cart.new": "Guardar carrito in nueva transacción",
 
+  "store/checkout.b2b.totalizer.boxTitle": "Encabezado del Pedido",
   "store/checkout.b2b.totalizer.shippingAddress": "Envío",
   "store/checkout.b2b.totalizer.billingAddress": "Dirección de Facturación",
   "store/checkout.b2b.totalizer.editAddress": "Editar",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -28,6 +28,7 @@
   "store/checkout.b2b.savedCarts.save-cart.current": "Salvar carrinho na mesma negociação",
   "store/checkout.b2b.savedCarts.save-cart.new": "Salvar carrinho em nova negociação",
 
+  "store/checkout.b2b.totalizer.boxTitle": "Cabeçalho do Pedido",
   "store/checkout.b2b.totalizer.shippingAddress": "Entrega",
   "store/checkout.b2b.totalizer.billingAddress": "Endereço de Cobrança",
   "store/checkout.b2b.totalizer.editAddress": "Editar",

--- a/react/CheckoutB2B.tsx
+++ b/react/CheckoutB2B.tsx
@@ -7,6 +7,7 @@ import 'vtex.country-codes/locales'
 import { useCssHandles } from 'vtex.css-handles'
 import { ExtensionPoint, useRuntime } from 'vtex.render-runtime'
 import {
+  Box,
   Button,
   Layout,
   PageBlock,
@@ -291,8 +292,10 @@ function CheckoutB2B() {
         <PageBlock>
           {!loading && (
             <div className="mb4">
-              <ContactInfos />
-              <Totalizer items={totalizers} />
+              <Box title={formatMessage(messages.totalizerBoxTitle)}>
+                <ContactInfos />
+                <Totalizer items={totalizers} />
+              </Box>
             </div>
           )}
 

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -123,6 +123,9 @@ export const messages = defineMessages({
   searchEmptyCart: {
     id: 'store/checkout.b2b.search.products.EmptyCart',
   },
+  totalizerBoxTitle: {
+    id: 'store/checkout.b2b.totalizer.boxTitle',
+  },
   costCentersLabel: {
     id: 'store/checkout.b2b.cost-centers.label',
   },


### PR DESCRIPTION
#### What problem is this solving?

This change introduces a `<Box>` component around the `Totalizer` and `ContactInfos` components. The purpose is to visually group and highlight the totalizer information, improving the clarity and organization of the layout for users.

#### How to test it?

[Workspace](https://raabelo--bravtexfashionb2b.myvtex.com/checkout-b2b)

Make sure the `Box` component appears correctly around the totalizers when the page is loaded and that it includes inner components. The box should only render once loading is complete (`!loading`).

#### Screenshots or example usage:

<img width="1870" height="746" alt="image" src="https://github.com/user-attachments/assets/302e3d6a-d549-4f77-9e8d-05b8cf1d24a0" />
