### PR TITLE
feat: use InputCurrency with dynamic locale and currency in ManualPrice

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -74,6 +74,7 @@
   "store/checkout.b2b.manualPrice.placeOrder": "All prices were successfully updated",
   "store/checkout.b2b.manualPrice.placeOrder.error": "Error updating prices:",
   "store/checkout.b2b.manualPrice.placeOrder.success": "Prices updated successfully",
+  "store/checkout.b2b.manualPrice.input.placeholder": "Type a monetary value",
 
   "store/checkout.b2b.search.placeholder": "Search by SKU name or EAN",
   "store/checkout.b2b.search.products.error": "Error loading products. Please try again later.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -74,6 +74,7 @@
   "store/checkout.b2b.manualPrice.placeOrder": "Todos los precios se actualizaron con éxito",
   "store/checkout.b2b.manualPrice.placeOrder.error": "Error al actualizar los precios:",
   "store/checkout.b2b.manualPrice.placeOrder.success": "Precios actualizados con éxito",
+  "store/checkout.b2b.manualPrice.input.placeholder": "Escriba un valor monetario",
 
   "store/checkout.b2b.search.placeholder": "Buscar por nombre de SKU o EAN",
   "store/checkout.b2b.search.products.error": "Error al cargar los productos. Inténtelo de nuevo más tarde.",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -74,6 +74,7 @@
   "store/checkout.b2b.manualPrice.placeOrder": "Todos os preços foram atualizados com sucesso",
   "store/checkout.b2b.manualPrice.placeOrder.error": "Erro ao atualizar os preços:",
   "store/checkout.b2b.manualPrice.placeOrder.success": "Preço atualizado",
+  "store/checkout.b2b.manualPrice.input.placeholder": "Digite um valor monetário",
 
   "store/checkout.b2b.search.placeholder": "Pesquisar por nome do SKU ou EAN",
   "store/checkout.b2b.search.products.error": "Erro ao carregar os produtos. Tente novamente mais tarde.",

--- a/react/components/ManualPrice.tsx
+++ b/react/components/ManualPrice.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import type { Item } from 'vtex.checkout-graphql'
 import { FormattedPrice } from 'vtex.formatted-price'
-import { Input } from 'vtex.styleguide'
+import { useRuntime } from 'vtex.render-runtime'
+import { InputCurrency } from 'vtex.styleguide'
 
 interface ManualPriceProps {
   rowData: Item
@@ -16,51 +17,50 @@ export default function ManualPrice({
   sliderValue,
   onUpdatePrice,
 }: ManualPriceProps) {
-  const [customPrice, setCustomPrice] = useState<string>(
-    String((rowData.sellingPrice ?? 0) / 100)
+  const {
+    culture: { locale, currency },
+  } = useRuntime()
+
+  const [customPrice, setCustomPrice] = useState<number>(
+    (rowData.sellingPrice ?? 0) / 100
   )
 
   const discountedPrice = (rowData.sellingPrice ?? 0) * (1 - sliderValue / 100)
 
   useEffect(() => {
-    const numericPrice = parseFloat(customPrice.replace(',', '.'))
-
-    if (numericPrice) {
-      onUpdatePrice(rowData.id, numericPrice * 100 || 0)
-    }
+    onUpdatePrice(rowData.id, Math.round(customPrice * 100))
   }, [customPrice, onUpdatePrice, rowData.id])
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCustomPrice(e.target.value)
-  }
+  const handleInputCurrencyChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const value = Number(e.target.value)
 
-  const handleInputBlur = () => {
-    const newValue = parseFloat(customPrice.replace(',', '.'))
-
-    if (newValue) {
-      setCustomPrice(newValue.toFixed(2))
+    if (!Number.isNaN(value)) {
+      setCustomPrice(value)
     }
   }
 
   if (isEditing && sliderValue === 0) {
     return (
-      <div style={{ minWidth: 110 }}>
-        <Input
+      <div style={{ minWidth: 110, transform: 'scale(0.85)' }}>
+        <InputCurrency
           size="small"
+          placeholder="Type a monetary value"
+          locale={locale}
+          currencyCode={currency}
           value={customPrice}
-          onChange={handleInputChange}
-          onBlur={handleInputBlur}
-          placeholder="Enter price"
+          onChange={handleInputCurrencyChange}
         />
       </div>
     )
   }
 
   return (
-    <FormattedPrice
-      value={
-        sliderValue > 0 ? discountedPrice / 100 : parseFloat(customPrice) || 0
-      }
-    />
+    <>
+      <FormattedPrice
+        value={sliderValue > 0 ? discountedPrice / 100 : customPrice || 0}
+      />
+    </>
   )
 }

--- a/react/components/ManualPrice.tsx
+++ b/react/components/ManualPrice.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react'
+import { useIntl } from 'react-intl'
 import type { Item } from 'vtex.checkout-graphql'
 import { FormattedPrice } from 'vtex.formatted-price'
 import { useRuntime } from 'vtex.render-runtime'
 import { InputCurrency } from 'vtex.styleguide'
+
+import { messages } from '../utils'
 
 interface ManualPriceProps {
   rowData: Item
@@ -17,6 +20,8 @@ export default function ManualPrice({
   sliderValue,
   onUpdatePrice,
 }: ManualPriceProps) {
+  const { formatMessage } = useIntl()
+
   const {
     culture: { locale, currency },
   } = useRuntime()
@@ -46,7 +51,7 @@ export default function ManualPrice({
       <div style={{ minWidth: 110, transform: 'scale(0.85)' }}>
         <InputCurrency
           size="small"
-          placeholder="Type a monetary value"
+          placeholder={formatMessage(messages.manualPricePlaceholder)}
           locale={locale}
           currencyCode={currency}
           value={customPrice}

--- a/react/utils/messages.ts
+++ b/react/utils/messages.ts
@@ -99,6 +99,9 @@ export const messages = defineMessages({
   manualPriceSuccessMessage: {
     id: 'store/checkout.b2b.manualPrice.placeOrder.success',
   },
+  manualPricePlaceholder: {
+    id: 'store/checkout.b2b.manualPrice.input.placeholder',
+  },
   createdIn: { id: 'store/checkout.b2b.column.createdIn' },
   items: { id: 'store/checkout.b2b.column.item' },
 


### PR DESCRIPTION
#### What problem is this solving?

The `ManualPrice` component was using a generic `<Input />`  field  from Vtex Styleguide for monetary values, which required manual string parsing, formatting, and caused locale/currency inconsistencies.  
This update replaces it with VTEX’s native `<InputCurrency />` component, ensuring proper formatting, input behavior, and dynamic currency/locale support based on the store's runtime configuration.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace](https://raabelo--bravtexfashionb2b.myvtex.com/checkout-b2b)

1. Go to the page where the `ManualPrice` component is used (e.g., B2B checkout or admin table).
2. Toggle the component into editing mode (`isEditing: true`).
3. Confirm the input is correctly formatted with the appropriate currency and locale.
4. Change the value and ensure it updates the price as expected.

#### Screenshots or example usage:

Before:
- Raw input with no currency symbol and incorrect formatting.

After:
- Properly formatted currency input using `InputCurrency`, with dynamic locale and symbol:
  - `pt-BR` → `R$ 120,00`
  - `en-US` → `$120.00`
  
 Screenshot of the style of the new component
 
<img width="159" height="125" alt="image" src="https://github.com/user-attachments/assets/431a21fe-1761-469b-98e9-c2c697907d16" />

#### Describe alternatives you've considered, if any.

- Keeping the `<Input />` and continuing to format the value manually with `Intl.NumberFormat`.
- Creating a custom masked input using useFormatPrice hook to simulate currency behavior.

However, both options were more error-prone and less consistent with VTEX's UI standards. Using `InputCurrency` is the recommended and supported approach for monetary values within VTEX IO apps.
