### PR TITLE
feat: representative balance settings graphql

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -17,11 +17,17 @@ type SavedCart {
   childrenQuantity: Int
 }
 
+type RepresentativeBalanceSettings {
+  enabled: Boolean!
+  openingBalance: Float!
+}
+
 type AppSettings {
   salesRepresentative: Int!
   salesManager: Int!
   salesAdmin: Int!
-  rolesAllowedToSeeMargin: [String]
+  rolesAllowedToSeeMargin: [String]!
+  representativeBalance: RepresentativeBalanceSettings!
 }
 
 type B2BOrder {
@@ -39,16 +45,20 @@ input ItemsUpdatePriceInput {
 type RepresentativeBalance {
   id: ID!
   email: String!
-  balance: Int!
+  balance: Float!
   createdIn: String!
   lastInteractionIn: String!
 }
 
 type Query {
   getCart(id: ID!): SavedCart
+
   getSavedCarts(parentCartId: ID): [SavedCart!]!
+
   getAppSettings: AppSettings!
+
   getRepresentativeBalances: [RepresentativeBalance]!
+
   getRepresentativeBalanceByEmail(email: String): RepresentativeBalance
 }
 
@@ -74,6 +84,11 @@ type Mutation {
 
   saveRepresentativeBalance(
     email: String
-    balance: Int!
+    balance: Float!
   ): RepresentativeBalance!
+
+  saveRepresentativeBalanceSettings(
+    enabled: Boolean!
+    openingBalance: Float!
+  ): RepresentativeBalanceSettings!
 }

--- a/manifest.json
+++ b/manifest.json
@@ -140,7 +140,7 @@
     "availableCountries": ["*"]
   },
   "settingsSchema": {
-    "title": "Configurações de Checkout B2B",
+    "title": "Checkout B2B Settings",
     "type": "object",
     "properties": {
       "salesRepresentative": {
@@ -197,6 +197,23 @@
           "customer-buyer": {
             "type": "boolean",
             "title": "Customer Buyer"
+          }
+        }
+      },
+      "representativeBalance": {
+        "title": "Representative Balance Settings",
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "title": "Enable Representative Balance",
+            "description": "Enable the Representative Balance feature in the store",
+            "default": false
+          },
+          "openingBalance": {
+            "type": "number",
+            "title": "Opening Balance",
+            "description": "The monetary value of the representative opening balance"
           }
         }
       }

--- a/node/resolvers/index.ts
+++ b/node/resolvers/index.ts
@@ -2,6 +2,7 @@ import { deleteCart } from './mutations/deleteCart'
 import { placeOrder } from './mutations/placeOrder'
 import { saveCart } from './mutations/saveCart'
 import { saveRepresentativeBalance } from './mutations/saveRepresentativeBalance'
+import { saveRepresentativeBalanceSettings } from './mutations/saveRepresentativeBalanceSettings'
 import { updatePrices } from './mutations/updatePrices'
 import { getAppSettings } from './queries/getAppSettings'
 import { getCart } from './queries/getCart'
@@ -24,6 +25,7 @@ export default {
       placeOrder,
       updatePrices,
       saveRepresentativeBalance,
+      saveRepresentativeBalanceSettings,
     },
   },
 }

--- a/node/resolvers/mutations/saveRepresentativeBalanceSettings.ts
+++ b/node/resolvers/mutations/saveRepresentativeBalanceSettings.ts
@@ -1,0 +1,27 @@
+import { ServiceContext } from '@vtex/api'
+
+import { Clients } from '../../clients'
+import { APP_ID } from '../../utils'
+
+export const saveRepresentativeBalanceSettings = async (
+  _: unknown,
+  { enabled, openingBalance }: { enabled: boolean; openingBalance: number },
+  context: ServiceContext<Clients>
+) => {
+  const settings = await context.clients.apps.getAppSettings(APP_ID)
+
+  const updatedRepresentativeBalance = {
+    ...settings.representativeBalance,
+    enabled,
+    openingBalance,
+  }
+
+  const updatedSettings = {
+    ...settings,
+    representativeBalance: updatedRepresentativeBalance,
+  }
+
+  await context.clients.apps.saveAppSettings(APP_ID, updatedSettings)
+
+  return updatedRepresentativeBalance
+}

--- a/node/resolvers/queries/getAppSettings.ts
+++ b/node/resolvers/queries/getAppSettings.ts
@@ -1,24 +1,36 @@
 import { ServiceContext } from '@vtex/api'
 
 import { Clients } from '../../clients'
+import { APP_ID } from '../../utils'
+
+const DEFAULT_ROLES_ALLOWED_TO_SEE_MARGIN = [
+  'store-admin',
+  'sales-admin',
+  'sales-manager',
+  'sales-representative',
+]
 
 export const getAppSettings = async (
   _: unknown,
   __: unknown,
   context: ServiceContext<Clients>
 ) => {
-  const settings = await context.clients.apps.getAppSettings(
-    process.env.VTEX_APP_ID ?? ''
-  )
+  const settings = await context.clients.apps.getAppSettings(APP_ID)
 
   const rolesAllowedToSeeMargin = settings.rolesAllowedToSeeMargin
     ? Object.entries(settings.rolesAllowedToSeeMargin)
         .filter(([, isAllowed]) => isAllowed)
         .map(([role]) => role)
-    : []
+    : DEFAULT_ROLES_ALLOWED_TO_SEE_MARGIN
+
+  const representativeBalance = {
+    enabled: settings.representativeBalance?.enabled ?? false,
+    openingBalance: settings.representativeBalance?.enabled ?? 0,
+  }
 
   return {
     ...settings,
     rolesAllowedToSeeMargin,
+    representativeBalance,
   }
 }

--- a/node/utils/constants.ts
+++ b/node/utils/constants.ts
@@ -1,0 +1,1 @@
+export const APP_ID = process.env.VTEX_APP_ID as string

--- a/node/utils/index.ts
+++ b/node/utils/index.ts
@@ -10,6 +10,7 @@ import {
   SCHEMA_VERSION,
 } from './mdSchema'
 
+export * from './constants'
 export * from './mdSchema'
 
 export async function getSessionData(context: ServiceContext<Clients>) {

--- a/react/graphql/getRepresentativeBalanceSettings.graphql
+++ b/react/graphql/getRepresentativeBalanceSettings.graphql
@@ -1,11 +1,8 @@
-query getSettings {
+query getRepresentativeBalanceSettings {
   getAppSettings @context(provider: "ssesandbox04.checkout-b2b") {
-    salesRepresentative
-    salesManager
-    salesAdmin
-    rolesAllowedToSeeMargin
     representativeBalance {
       enabled
+      openingBalance
     }
   }
 }

--- a/react/graphql/saveRepresentativeBalanceSettings.graphql
+++ b/react/graphql/saveRepresentativeBalanceSettings.graphql
@@ -1,0 +1,12 @@
+query saveRepresentativeBalanceSettings(
+  $enabled: Boolean!
+  $openingBalance: Float!
+) {
+  saveRepresentativeBalanceSettings(
+    enabled: $enabled
+    openingBalance: $openingBalance
+  ) @context(provider: "ssesandbox04.checkout-b2b") {
+    enabled
+    openingBalance
+  }
+}

--- a/react/hooks/usePermissions.ts
+++ b/react/hooks/usePermissions.ts
@@ -12,6 +12,9 @@ interface AppSettings {
   salesManager: number
   salesAdmin: number
   rolesAllowedToSeeMargin?: string[]
+  representativeBalance: {
+    enabled: boolean
+  }
 }
 
 export function usePermissions() {
@@ -19,7 +22,7 @@ export function usePermissions() {
     ssr: false,
   })
 
-  const appSettings = data?.getAppSettings as AppSettings
+  const appSettings = data?.getAppSettings as AppSettings | undefined
 
   const { organization } = useOrganization()
   const { role } = organization
@@ -56,5 +59,13 @@ export function usePermissions() {
     [appSettings, role]
   )
 
-  return { isSalesUser, maximumDiscount, canSeeMargin }
+  const representativeBalanceEnabled =
+    appSettings?.representativeBalance.enabled ?? false
+
+  return {
+    isSalesUser,
+    maximumDiscount,
+    canSeeMargin,
+    representativeBalanceEnabled,
+  }
 }


### PR DESCRIPTION
### Backend features
- Adds the field `representativeBalance` to `getAppSettings` query.
- Creates the `saveRepresentativeBalanceSettings` mutation.

### Frontend features

- New field `representativeBalanceEnabled` returned by `userPermissions` hook.
- For admin:
  - Query selection file at `react/graphql/getRepresentativeBalanceSettings.graphql` to read current representative balance settings: `enabled` (boolean) and `openingBalance` (number).
  - Mutation execution file at `react/graphql/saveRepresentativeBalanceSettings.graphql` to save representative balance settings.