### PR TITLE
feat: add proper pagination to representative balance transactions

### DIFF
--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -75,6 +75,17 @@ input UpdateItemsQuantityInput {
   quantity: Int!
 }
 
+type Pagination {
+  total: Int!
+  page: Int!
+  pageSize: Int!
+}
+
+type RepresentativeBalanceTransactionResponse {
+  data: [RepresentativeBalanceTransaction]! @CheckSchemas
+  pagination: Pagination!
+}
+
 type Query {
   getCart(id: ID!): SavedCart @CheckSchemas
 
@@ -92,7 +103,7 @@ type Query {
     page: Int
     pageSize: Int
     sort: String
-  ): [RepresentativeBalanceTransaction]! @CheckSchemas
+  ): RepresentativeBalanceTransactionResponse! @CheckSchemas
 }
 
 type Mutation {

--- a/messages/context.json
+++ b/messages/context.json
@@ -135,8 +135,8 @@
   "admin/representativebalances.transactions.last-interaction": "Last Interaction",
   "admin/representativebalances.transactions.order-group": "Order",
   "admin/representativebalances.transactions.back-to-representative": "Back to Representatives",
-  "admin/representativebalances.transactions.page-back": "Previous",
-  "admin/representativebalances.transactions.page-next": "Next",
+  "admin/representativebalances.transactions.page-back": "Most recent",
+  "admin/representativebalances.transactions.page-next": "Older",
   "admin/representativebalances.transactions.no-transactions-found": "No transactions found for {email}",
 
   "store/checkout.b2b.share-cart.button": "Share PDF",

--- a/messages/en.json
+++ b/messages/en.json
@@ -135,8 +135,8 @@
   "admin/representativebalances.transactions.last-interaction": "Last Interaction",
   "admin/representativebalances.transactions.order-group": "Order",
   "admin/representativebalances.transactions.back-to-representative": "Back to Representatives",
-  "admin/representativebalances.transactions.page-back": "Previous",
-  "admin/representativebalances.transactions.page-next": "Next",
+  "admin/representativebalances.transactions.page-back": "Most recent",
+  "admin/representativebalances.transactions.page-next": "Older",
   "admin/representativebalances.transactions.no-transactions-found": "No transactions found for {email}",
 
   "store/checkout.b2b.share-cart.button": "Share PDF",

--- a/messages/es.json
+++ b/messages/es.json
@@ -135,8 +135,8 @@
   "admin/representativebalances.transactions.last-interaction": "Última interacción",
   "admin/representativebalances.transactions.order-group": "Pedido",
   "admin/representativebalances.transactions.back-to-representative": "Volver a Representantes",
-  "admin/representativebalances.transactions.page-back": "Anterior",
-  "admin/representativebalances.transactions.page-next": "Siguiente",
+  "admin/representativebalances.transactions.page-back": "Más recientes",
+  "admin/representativebalances.transactions.page-next": "Más antiguas",
   "admin/representativebalances.transactions.no-transactions-found": "No se encontraron transacciones para {email}",
 
   "store/checkout.b2b.share-cart.button": "Compartir PDF",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -135,8 +135,8 @@
   "admin/representativebalances.transactions.last-interaction": "Última intereção",
   "admin/representativebalances.transactions.order-group": "Pedido",
   "admin/representativebalances.transactions.back-to-representative": "Voltar aos Representantes",
-  "admin/representativebalances.transactions.page-back": "Anterior",
-  "admin/representativebalances.transactions.page-next": "Próximo",
+  "admin/representativebalances.transactions.page-back": "Mais recentes",
+  "admin/representativebalances.transactions.page-next": "Mais antigas",
   "admin/representativebalances.transactions.no-transactions-found": "Nenhuma transação encontrada para {email}",
 
   "store/checkout.b2b.share-cart.button": "Compartilhar PDF",

--- a/node/resolvers/queries/getRepresentativeBalanceTransactions.ts
+++ b/node/resolvers/queries/getRepresentativeBalanceTransactions.ts
@@ -10,22 +10,23 @@ import {
 
 export const getRepresentativeBalanceTransactions = async (
   _: unknown,
-  {
-    email,
-    page,
-    pageSize,
-    sort,
-  }: QueryGetRepresentativeBalanceTransactionsArgs,
+  args: QueryGetRepresentativeBalanceTransactionsArgs,
   context: ServiceContext<Clients>
 ) => {
   const { masterdata } = context.clients
 
-  return masterdata.searchDocuments<RepresentativeBalanceTransaction>({
-    dataEntity: REPRESENTATIVE_BALANCE_TRANSACTION_ENTITY,
-    fields: REPRESENTATIVE_BALANCE_TRANSACTION_FIELDS,
-    schema: SCHEMA_VERSION,
-    where: `email="${email}"`,
-    pagination: { page: page ?? 1, pageSize: pageSize ?? 15 },
-    sort: sort ?? 'createdIn asc',
-  })
+  const { email, page = 1, pageSize = 20, sort = 'createdIn DESC' } = args
+
+  const response = await masterdata.searchDocumentsWithPaginationInfo<RepresentativeBalanceTransactionResponse>(
+    {
+      dataEntity: REPRESENTATIVE_BALANCE_TRANSACTION_ENTITY,
+      fields: REPRESENTATIVE_BALANCE_TRANSACTION_FIELDS,
+      schema: SCHEMA_VERSION,
+      where: `email="${email}"`,
+      pagination: { page: page ?? 1, pageSize: pageSize ?? 15 },
+      sort: sort ?? 'createdIn asc',
+    }
+  )
+
+  return response
 }

--- a/node/typings.ts
+++ b/node/typings.ts
@@ -88,6 +88,17 @@ declare global {
     orderGroup: string
   }>
 
+  type Pagination = {
+    total: number
+    page: number
+    pageSize: number
+  }
+
+  type RepresentativeBalanceTransactionResponse = {
+    data: RepresentativeBalanceTransaction[]
+    pagination: Pagination
+  }
+
   type AppSettings = {
     salesRepresentative: number
     salesManager: number

--- a/react/components/RepresentativeBalanceTransactions.tsx
+++ b/react/components/RepresentativeBalanceTransactions.tsx
@@ -32,6 +32,7 @@ const RepresentativeBalanceTransactions = ({
   const [page, setPage] = useState<number>(1)
   const {
     transactions,
+    pagination,
     loading: isLoadingTransactions,
     error,
   } = useFetchRepresentativeBalanceTransactions({ email, page })
@@ -183,8 +184,13 @@ const RepresentativeBalanceTransactions = ({
             >
               {formatMessage(messages.representativeBalanceTransactionPageBack)}
             </Button>
+
             <Button
-              disabled={!transactions.length}
+              disabled={
+                !transactions.length ||
+                !pagination ||
+                page * pagination.pageSize >= pagination.total
+              }
               isLoading={isLoadingTransactions}
               size="small"
               variation="primary"

--- a/react/graphql/getRepresentativeBalanceTransactions.graphql
+++ b/react/graphql/getRepresentativeBalanceTransactions.graphql
@@ -10,12 +10,19 @@ query GetRepresentativeBalanceTransactions(
     pageSize: $pageSize
     sort: $sort
   ) {
-    id,
-    createdIn,
-    lastInteractionIn,
-    email,
-    oldBalance,
-    newBalance,
-    orderGroup,
+    data {
+      id
+      email
+      oldBalance
+      newBalance
+      orderGroup
+      createdIn
+      lastInteractionIn
+    }
+    pagination {
+      total
+      page
+      pageSize
+    }
   }
 }

--- a/react/hooks/useFetchRepresentativeBalanceTransactions.ts
+++ b/react/hooks/useFetchRepresentativeBalanceTransactions.ts
@@ -26,8 +26,11 @@ export const useFetchRepresentativeBalanceTransactions = ({
     }
   )
 
+  const transactionsResponse = data?.getRepresentativeBalanceTransactions
+
   return {
-    transactions: data?.getRepresentativeBalanceTransactions ?? [],
+    transactions: transactionsResponse?.data ?? [],
+    pagination: transactionsResponse?.pagination,
     loading,
     error,
     refetch,


### PR DESCRIPTION
#### What problem is this solving?

Until now, the **Representative Balance Transactions** page loaded all transactions without real pagination, which could cause performance issues and make it harder for users to navigate.  

This PR introduces **server-side pagination** support for transactions:  
- Updates the backend to use `searchDocumentsWithPaginationInfo` from Masterdata.  
- Updates the `useFetchRepresentativeBalanceTransactions` hook to handle `pagination` (page, pageSize, total).  
- Updates the `RepresentativeBalanceTransactions` component to display pagination buttons.  
- Improves button labels to reflect chronological navigation:  
  - **Mais recentes** (instead of "Anterior")  
  - **Mais antigas** (instead of "Próximo")  

#### How to test it?

[Workspace](https://raabelo--bravtexfashionb2b.myvtex.com/admin/checkout-b2b/representative-balances/transactions/tiago.freire+sales-representative@cubos.io)

#### Screenshots or example usage:

<img width="1514" height="346" alt="image" src="https://github.com/user-attachments/assets/a8db5213-ab37-40a2-9759-fde5cf11030e" />
