### PR TITLE
feat: add a indicator of difference on balance transactions

### DIFF
--- a/react/components/RepresentativeBalanceTransactions.tsx
+++ b/react/components/RepresentativeBalanceTransactions.tsx
@@ -1,6 +1,14 @@
 import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
-import { Button, Link, Spinner, Table, Tooltip } from 'vtex.styleguide'
+import {
+  Button,
+  IconArrowDown,
+  IconArrowUp,
+  Link,
+  Spinner,
+  Table,
+  Tooltip,
+} from 'vtex.styleguide'
 
 import {
   useFetchRepresentativeBalance,
@@ -47,9 +55,22 @@ const RepresentativeBalanceTransactions = ({
         messages.representativeBalanceTransactionTransaction
       ),
       cellRenderer: function renderCell({ rowData }: { rowData: Transaction }) {
+        const difference = rowData.newBalance - rowData.oldBalance
+        const isPositive = difference > 0
+
+        const Icon = isPositive ? IconArrowUp : IconArrowDown
+        const formattedDiff = `${isPositive ? '+' : ''}${formatPrice(
+          difference
+        )}`
+
         return (
-          <Tooltip label={formatPrice(rowData.newBalance - rowData.oldBalance)}>
-            <span>{formatPrice(rowData.newBalance - rowData.oldBalance)}</span>
+          <Tooltip label={formatPrice(difference)}>
+            <div>
+              <span className={`ml3 ${isPositive ? 'c-success' : 'c-danger'}`}>
+                <Icon size={12} />
+              </span>
+              <span>{formattedDiff}</span>
+            </div>
           </Tooltip>
         )
       },


### PR DESCRIPTION
#### What problem is this solving?

Currently, representative balance transactions only display the numeric difference between the old balance and the new balance, without any clear visual indication of whether it was a **credit (positive)** or a **debit (negative)**.  
This makes it harder for users to quickly interpret the data.  

This PR introduces a **transaction difference indicator**:  
- Green upward arrow icon for positive transactions.  
- Red downward arrow icon for negative transactions.  
- Explicit `+` sign shown for positive values.  

#### How to test it?

[Workspace](https://raabelo--bravtexfashionb2b.myvtex.com/admin/checkout-b2b/representative-balances/transactions/tiago.freire+sales-representative@cubos.io)

#### Screenshots or example usage:

<img width="305" height="259" alt="image" src="https://github.com/user-attachments/assets/a6b5ef86-c83b-4aee-afa9-6991198d54dc" />

